### PR TITLE
Fixes for boolean na types, typos, na assignments in test cases (#110)

### DIFF
--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -62,7 +62,11 @@ def get_mapd_type_from_object(data):
         return 'DATE'
     elif isinstance(val, datetime.time):
         return 'TIME'
+    elif isinstance(val, bool):
+        return 'BOOL'
     elif isinstance(val, int):
+        if data.max() >= 2147483648 or data.min() <= -2147483648:
+            return 'BIGINT'
         return 'INT'
     else:
         raise TypeError("Unhandled type {}".format(data.dtype))
@@ -79,6 +83,9 @@ def thrift_cast(data, mapd_type):
     elif mapd_type == 'DATE':
         return date_to_seconds(data)
     elif mapd_type == 'BOOL':
+        # fillna before converting to int, since int cols
+        # in Pandas do not support None or NaN
+        data = data.fillna(mapd_to_na[mapd_type])
         return data.astype(int)
 
 

--- a/pymapd/_utils.py
+++ b/pymapd/_utils.py
@@ -20,7 +20,7 @@ def datetime_to_seconds(arr):
     import numpy as np
 
     if arr.dtype != np.dtype('datetime64[ns]'):
-        raise TypeError("Invalid type {}, expected datetime64[ns]".foramt(
+        raise TypeError("Invalid type {}, expected datetime64[ns]".format(
             arr.dtype))
     return arr.view('i8') // 10**9  # ns -> s since epoch
 
@@ -57,8 +57,8 @@ mapd_to_slot = {
 
 
 mapd_to_na = {
-    'BOOL': 0,
-    'BOOLEAN': 0,
+    'BOOL': -128,
+    'BOOLEAN': -128,
     'SMALLINT': -32768,
     'INT': -2147483648,
     'INTEGER': -2147483648,

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -78,7 +78,14 @@ class TestLoaders(object):
 
         data = pd.DataFrame({
             "boolean_": [True, False, None],
-            "bigint_": np.array([0, 1, None], dtype=np.object),
+            # Currently Pandas does not support storing None or NaN
+            # in integer columns, so int cols with null
+            # need to be objects. This means our type detection will be
+            # unreliable since if there is no number outside the int32
+            # bounds in a column with nulls then we will be assuming int
+            "int_": np.array([0, 1, None], dtype=np.object),
+            "bigint_": np.array([0, 9223372036854775807, None],
+                                dtype=np.object),
             "double_": np.array([0, 1, None], dtype=np.float64),
             "varchar_": ["a", "b", None],
             "text_": ['a', 'b', None],
@@ -86,20 +93,22 @@ class TestLoaders(object):
             "timestamp_": [pd.Timestamp("2016"), pd.Timestamp("2017"), None],
             "date_": [datetime.date(2016, 1, 1), datetime.date(2017, 1, 1),
                       None],
-        }, columns=['boolean_', 'bigint_',
+        }, columns=['boolean_', 'int_', 'bigint_',
                     'double_', 'varchar_', 'text_', 'time_', 'timestamp_',
                     'date_'])
         result = _pandas_loaders.build_input_columnar(data,
                                                       preserve_index=False)
 
         nulls = [False, False, True]
+        bool_na = -128
         int_na = -2147483648
         bigint_na = -9223372036854775808
         ns_na = -9223372037
 
         expected = [
-            TColumn(TColumnData(int_col=[1, 0, int_na]), nulls=nulls),
-            TColumn(TColumnData(int_col=np.array([0, 1, int_na], dtype=np.int64)), nulls=nulls),  # noqa
+            TColumn(TColumnData(int_col=[1, 0, bool_na]), nulls=nulls),
+            TColumn(TColumnData(int_col=np.array([0, 1, int_na], dtype=np.int32)), nulls=nulls),  # noqa
+            TColumn(TColumnData(int_col=np.array([0, 9223372036854775807, bigint_na], dtype=np.int64)), nulls=nulls),  # noqa
             TColumn(TColumnData(real_col=np.array([0, 1, np.nan], dtype=np.float64)), nulls=nulls),  # noqa
             TColumn(TColumnData(str_col=['a', 'b', '']), nulls=nulls),
             TColumn(TColumnData(str_col=['a', 'b', '']), nulls=nulls),


### PR DESCRIPTION
* Fix na types for boolean, fix test case na types, fillna prior to boolean Thrift cast to prevent type error

* Attempt to distinguish int from bigint when int column contains None, fix int64 test that was actually an in32 test, add int32 test case

* Fix linting issue